### PR TITLE
Fixed ArchiveURLSubset

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -110,7 +110,7 @@ PackageWWWHome := "http://www.math.colostate.edu/~hulpke/matgrp",
 PackageDoc := rec(
   # use same as in GAP            
   BookName := "matgrp",
-  ArchiveURLSubset := [ "doc/manual.pdf"],
+  ArchiveURLSubset := [ "doc", "htm" ],
   PDFFile := "doc/manual.pdf",
   HTMLStart:="htm/chapters.htm",
   # the path to the .six file used by GAP's help system


### PR DESCRIPTION
It should include the directory for the HTML version of the manual too.
