### PR TITLE
Don't depend on 'recogbase'

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -145,7 +145,6 @@ Dependencies := rec(
     ["genss", ">= 1.3"],
     ["Orb", ">= 3.4"],
     ["AtlasRep", ">= 1.4.0"],
-    ["recogbase", ">= 1.0"],
   ],
   SuggestedOtherPackages := [],
   ExternalConditions := []


### PR DESCRIPTION
This is not necessary, as the dependency on 'recog' already pulls it in.

Note that 'recogbase' has been merged into 'recog'; the only thing preventing
a release of the new 'recog' is the fact that 'matrgrp' directly depends on
'recogbase'.

As such, it would be great if a new 'matrgrp' release with this change in it
could be made, so that we can move forward with 'recog'.