### PR TITLE
Replace obsolete NormedVectors by NormedRowVectors

### DIFF
--- a/lib/recograt.gi
+++ b/lib/recograt.gi
@@ -1308,7 +1308,7 @@ local orbtranslimit,f,total,gens,mo,bas,basn,dims,a,p,vec,orb,t,dict,use,fct,
       else
         p:=p-1;
       fi;
-      orb:=OrbitsDomain(Group(gens),NormedVectors(VectorSpace(f,bas{[1..dims[p]]},Zero(bas[1]))),OnLines);
+      orb:=OrbitsDomain(Group(gens),NormedRowVectors(VectorSpace(f,bas{[1..dims[p]]},Zero(bas[1]))),OnLines);
       orb:=Filtered(orb,x->Length(x)>1);
       Sort(orb,function(a,b) return Length(a)>Length(b);end);
       vec:=List(orb,x->x[1]);


### PR DESCRIPTION
This has been reported at https://travis-ci.org/gap-system/gap-docker-pkg-tests-master/jobs/446931103

```
########> Diff in /home/gap/inst/gap-master/pkg/matgrp/tst/basic.tst:18
# Input is:
ffs:=FittingFreeLiftSetup(h);;
# Expected output:
# But found:
#I  'NormedVectors' is obsolete.
#I  It may be removed in a future release of GAP.
#I  Use NormedRowVectors instead.
########
```