### PR TITLE
Some trivial changes

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -127,9 +127,6 @@ PackageDoc := rec(
   # a longer title of the book, this together with the book name should
   # fit on a single text line (appears with the '?books' command in GAP)
   LongTitle := "Matrix Group Interface",
-  # Should this help book be autoloaded when GAP starts up? This should
-  # usually be 'true', otherwise say 'false'. 
-  Autoload := true
 ),
 
 
@@ -164,12 +161,6 @@ Dependencies := rec(
 AvailabilityTest := ReturnTrue,
 
 TestFile := "tst/testall.g",
-
-##  Suggest here if the package should be *automatically loaded* when GAP is 
-##  started.  This should usually be 'false'. Say 'true' only if your package 
-##  provides some improvements of the GAP library which are likely to enhance 
-##  the overall system performance for many users.
-Autoload := false,
 
 ##  If the default banner does not suffice then provide a string that is
 ##  printed when the package is loaded (not when it is autoloaded or if

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Download from
 http://www.math.colostate.edu/~hulpke/matgrp/
 
 It is Copyright (C) 2016-20 by Alexander Hulpke
-It is licensed under GPL v2 or v3. (see http://gnu.org/licenses/gpl.html)
+It is licensed under GPL v2 or v3. (see https://gnu.org/licenses/gpl.html)
 
 At this point no methods for functions (such as ConjugacyClasses) exist
 that automatically apply to matrix groups. However if calling

--- a/doc/gapmacro.tex
+++ b/doc/gapmacro.tex
@@ -141,7 +141,7 @@
     /Author (The GAP Group)
     }
     \pdfcatalog{
-    /URI (http://www.gap-system.org)
+    /URI (https://www.gap-system.org)
 %    /PageMode /UseOutlines}
     /PageMode /UseNone}
     \pdfcompresslevel 9

--- a/doc/manual.tex
+++ b/doc/manual.tex
@@ -23,7 +23,6 @@
 %%
 %F  UseReferences . . . . . . . . . . . . . . . . . .  specify references
 %%
-% \UseReferences{../../../doc/ext}
 % \UseReferences{../../../doc/ref}
 %
 %

--- a/doc/matgrp.tex
+++ b/doc/matgrp.tex
@@ -23,7 +23,7 @@ packages.
 It is copyright (C) 2018 by Alexander Hulpke and released under version 2
 and version 3 of the GPL. (It is a bad habit to include copies of the GPL in
 software, as it can easily be found under
-\URL{http://gnu.org/licenses/gpl.html}.)
+\URL{https://gnu.org/licenses/gpl.html}.)
 
 If you were able to install the prerequisite package {\sf recog}, you will
 have no problems in installing {\sf matgrp}, which is plain {\GAP} code.


### PR DESCRIPTION
Prefer https over http, remove obsolete autoload, remove reference to
non-existent doc/ext manual in GAP
