### PR TITLE
converting to NC version of PreImages...

### DIFF
--- a/init.g
+++ b/init.g
@@ -7,4 +7,14 @@
 ##
 #############################################################################
 
+#I introducing globally the NC versions of PreImages...  
+if not IsBound( PreImagesSetNC ) then 
+    BindGlobal( "PreImagesSetNC", PreImagesSet ); 
+fi; 
+if not IsBound( PreImagesRepresentativeNC ) then 
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative ); 
+fi; 
+
+#############################################################################
+
 ReadPackage("matgrp","lib/recograt.gd");

--- a/lib/recograt.gi
+++ b/lib/recograt.gi
@@ -741,7 +741,7 @@ doesaut,biggens,wrimages,m,w,e,poolimggens,img,localgens,dfgens,wrs,dfimgs,b,per
 
 	  if d=i then
 	    # pull generator images back in original group
-	    genimgs[kn][i]:=List(genims,x->PreImagesRepresentative(isom,x));
+	    genimgs[kn][i]:=List(genims,x->PreImagesRepresentativeNC(isom,x));
 
 #if ForAny(Flat(genimgs),x->not x in Image(csi.permap[pools[poolnum][1]])) then
 #  Error("imerrD");
@@ -797,7 +797,7 @@ doesaut,biggens,wrimages,m,w,e,poolimggens,img,localgens,dfgens,wrs,dfimgs,b,per
 	      # newly included component -- the generators *are* simply the
 	      # images
 	      genimgs[kn][i]:=List(genims,
-	        x->PreImagesRepresentative(isoms[d],x));
+	        x->PreImagesRepresentativeNC(isoms[d],x));
 
 #if ForAny(Flat(genimgs),x->not x in Image(csi.permap[pools[poolnum][1]])) then
   #Error("imerrB");
@@ -905,7 +905,7 @@ doesaut,biggens,wrimages,m,w,e,poolimggens,img,localgens,dfgens,wrs,dfimgs,b,per
 			x->ImagesRepresentative(csi.permap[pools[i][l]],
 			  CSIImageHomNr(csi,pools[i][l],x^CSINiceGens(csi,kn))));
 		if isoms[j]<>false then
-		  d:=List(d,x->PreImagesRepresentative(isoms[j],x));
+		  d:=List(d,x->PreImagesRepresentativeNC(isoms[j],x));
 		fi;
 		d:=Image(e[l],CSIAelement(a,localgens,d));
 	      else
@@ -1008,7 +1008,7 @@ local csi,pools,result,i,e,a,img,b,dp,d,kn,perm,l;
 	      x->ImagesRepresentative(csi.permap[dp],
 		CSIImageHomNr(csi,dp,x^elm)));
       if dci.isoms[dp]<>false then
-	d:=List(d,x->PreImagesRepresentative(dci.isoms[dp],x));
+	d:=List(d,x->PreImagesRepresentativeNC(dci.isoms[dp],x));
       fi;
       d:=Image(e[l],CSIAelement(a,dci.poollocalgens[i],d));
       img:=img*d;
@@ -1044,15 +1044,15 @@ end);
 
 #############################################################################
 ##
-#M  PreImagesSet(<hom>,<x>)
+#M  PreImagesSetNC(<hom>,<x>)
 ##
-InstallMethod(PreImagesSet,"for recognition mappings", CollFamRangeEqFamElms,
+InstallMethod(PreImagesSetNC,"for recognition mappings", CollFamRangeEqFamElms,
   [ IsGroupGeneralMapping and
   HasRecogDecompinfoHomomorphism,IsGroup], 0,
 function(hom, U)
 local gens,pre;
   gens:=SmallGeneratingSet(U);
-  pre:=List(gens,x->PreImagesRepresentative(hom,x));
+  pre:=List(gens,x->PreImagesRepresentativeNC(hom,x));
   U:=RecogDecompinfoHomomorphism(hom).LiftSetup;
   U:=SubgroupByFittingFreeData(Source(hom),pre,gens,U.pcgs);
   return U;
@@ -2859,7 +2859,7 @@ local ffu,ff,x;
   if not x in Image(ffu.rest) then
     return false;
   fi;
-  elm:=elm/PreImagesRepresentative(ffu.rest,x);
+  elm:=elm/PreImagesRepresentativeNC(ffu.rest,x);
   elm:=ImagesRepresentative(ff.pcisom,elm);
   if not IsBound(ffu.pcsub) then
     ffu.pcsub:=Subgroup(Image(ff.pcisom),


### PR DESCRIPTION
PreImages, PreImagesElm, PreImagesSet and PreImagesRepresetnative, can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809.
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions.
The procedure to be adopted is as follows.
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these. PR #5073 addresses this.
(2) Ask package authors/maintainers to convert all their calls to these functions to the NC versions (unless there is good reason not to do so).
A clause added to init.g ensures that the package still works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations.
This PR attempts to implement (2) for package matgrp which calls PreImagesRepresentative six times, and has an InstallMethod for PreImagesSet.
This PR only created now because unaware until today of the webpage for matgrp on GitHub.
The plan is to complete PR #5073 at the GAP days in March.