### PR TITLE
Remove NonField recognition 'method'

### DIFF
--- a/lib/recograt.gi
+++ b/lib/recograt.gi
@@ -13,38 +13,9 @@ SetInfoLevel(InfoRecog,0); # recog will print status messages otherwise
 # mod to recog -- rings
 
 # newer recog has some changes to these internal APIs
-if not IsBound(RIFac) and IsBound(ImageRecogNode) then
-  RIFac := ImageRecogNode;
-  RIKer := KernelRecogNode;
-fi;
-
-if IsBound(BindRecogMethod) then
-
-BindRecogMethod(FindHomMethodsMatrix, "Nonfield",
-"catch matrix groups defined over nonfield rings",
-function(ri, G)
-  if IsBound(ri!.ring) and not IsBound(ri!.field) then
-    Error("hereIAm");
-  fi;
-  return false;
-end);
-
-AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.Nonfield, 5100);
-
-
-else
-
-FindHomMethodsMatrix.Nonfield := function(ri, G)
-  if IsBound(ri!.ring) and not IsBound(ri!.field) then
-    Error("hereIAm");
-  fi;
-  return false;
-end;
-
-AddMethod( FindHomDbMatrix, FindHomMethodsMatrix.Nonfield,
-  5100, "Nonfield",
-          "catch matrix groups defined over nonfield rings" );
-
+if not IsBound(ImageRecogNode) then
+  ImageRecogNode := RIFac;
+  KernelRecogNode := RIKer;
 fi;
 
 OnSubmoduleCosets:=function(cset,g)
@@ -475,9 +446,9 @@ local treerecurse,n,factors,homs,leafgens,niceranges,genum,sz,leafs,g,
       genum:=genum+f;
     else
       #hom:=Homom(r);
-      f:=RIFac(r);
+      f:=ImageRecogNode(r);
       treerecurse(f,Concatenation(h,[1]));
-      k:=RIKer(r);
+      k:=KernelRecogNode(r);
       if k<>fail then
 	treerecurse(k,Concatenation(h,[0]));
       fi;
@@ -529,10 +500,10 @@ local r,h,i;
   h:=csi.homs[n];
   for i in h do
     if i=0 then
-      r:=RIKer(r);
+      r:=KernelRecogNode(r);
     elif i=1 then
       x:=ImageElm(Homom(r),x);
-      r:=RIFac(r);
+      r:=ImageRecogNode(r);
     else
       x:=ImageElm(csi.furtherhom[i],x);
     fi;


### PR DESCRIPTION
In plain recog, there will never be a 'ring' component in a
recognition node, so this code did nothing, unless mixed with
further code which not included in this repo or the recog repo.

Motivation: recog has again slightly changed the way
BindRecogMethod and methods work (the input arguments to
`BindRecogMethod` have changed, as have the inputs and outputs of
the recognition methods themselves). We've put in a workaround to
accommodate matgrp, but it's preferable to solve this issue once
and for all here.
